### PR TITLE
Bubble force_credentials up to sendemail.R

### DIFF
--- a/R/sendemail.R
+++ b/R/sendemail.R
@@ -5,7 +5,7 @@
 #' @param html A character string specifying the message body (as HTML). Must specify \code{html}, \code{message}, or both; or alternatively \code{raw}.
 #' @param raw A raw vector containing a valid email body (of no more than 10MB in size). Can only specify \code{raw} xor \code{message}/\code{html}.
 #' @param subject A character string specifying the email subject
-#' @param from A character string specifying teh sender
+#' @param from A character string specifying the sender. Must be AWS SES verified.
 #' @param to A character vector of TO recipient email addresses.
 #' @param cc A character vector of CC recipient email addresses.
 #' @param bcc A character vector of BCC recipient email addresses.
@@ -14,8 +14,12 @@
 #' @param charset.message An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{message} is not ASCII.
 #' @param charset.html An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{html} is not ASCII.
 #' @param charset.subject An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{subject} is not ASCII.
+#' @param key A character string with the key from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param secret  A character string with the secret from from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param region A character string giving the region of the user's Amazon SES service. Note that AWS SES is only available in regions us-east-1, us-west-2, or eu-west-1.
+#' @param force_credentials A logical set to \code{TRUE} or \code{FALSE}. Use \code{TRUE} only if you are providing the key, secret, and region parameters.
 #' @template dots
-#' @details Send a test or raw email message. \code{get_quota} and \code{get_statistics} provide information on remaining and used email rate limits, respectively.
+#' @details Send a test or raw email message. \code{get_quota} and \code{get_statistics} provide information on remaining and used email rate limits, respectively. To use Amazon SES from any host, in AWS Identity and Access Management (IAM), create a new user with no password, directly attach an SES permission policy (eg: AmazonSESFullAccess), then in that user's "Security credentials" tab, click "Create access key". This will allow you to download a .csv file with a key and secret to use here. In this case, also set the \code{region} parameter to the region of your Amazon SES service and the \code{force_credentials} parameter to \code{TRUE}.
 #' @return A character string containg the message ID.
 #' @examples
 #' \dontrun{
@@ -26,18 +30,18 @@
 #' a <- get_verification_attrs("me@example.com")
 #' if (a[[1]]$VerificationStatus == "Success") {
 #'   # simple plain-text email
-#'   send_email("Test Email Body", subject = "Test Email", 
+#'   send_email("Test Email Body", subject = "Test Email",
 #'              from = "me@example.com", to = "recipient@example.com")
-#' 
+#'
 #'   # html and plain text versions
-#'   send_email(message = "Plain text body", 
-#'              html = "<div><p style='font-weight=bold;'>HTML text body</p></div>", 
-#'              subject = "Test Email", 
+#'   send_email(message = "Plain text body",
+#'              html = "<div><p style='font-weight=bold;'>HTML text body</p></div>",
+#'              subject = "Test Email",
 #'              from = "me@example.com", to = "recipient@example.com")
 #' }
 #' }
 #' @export
-send_email <- 
+send_email <-
 function(message,
          html,
          raw = NULL,
@@ -51,9 +55,14 @@ function(message,
          charset.subject = NULL,
          charset.message = NULL,
          charset.html = NULL,
+         key = NULL,
+         secret = NULL,
+         region = NULL,
+         force_credentials = FALSE,
          ...) {
+
     query <- list(Source = from)
-    
+
     # configure message body and subject
     if (!is.null(raw)) {
         query[["Action"]] <- "SendRawEmail"
@@ -80,7 +89,7 @@ function(message,
             query[["Message.Subject.Charset"]] <- charset.subject
         }
     }
-    
+
     # configure recipients
     if (length(c(to,cc,bcc)) > 50L) {
         stop("The total number of recipients cannot exceed 50.")
@@ -97,15 +106,18 @@ function(message,
         names(bcc) <- paste0("Destination.BccAddresses.member.", seq_along(bcc))
         query <- c(query, bcc)
     }
-    
     if (!is.null(replyto)) {
-      query[["ReplyToAddresses"]] <- replyto
+        names(replyto) <- paste0("ReplyToAddresses.member.", seq_along(replyto))
+        query <- c(query, replyto)
     }
     if (!is.null(returnpath)) {
       query[["ReturnPath"]] <- returnpath
     }
-    
-    r <- sesPOST(body = query, ...)
-    structure(r[["SendEmailResponse"]][["SendEmailResult"]][["MessageId"]],
-              RequestId = r[["SendEmailResponse"]][["ResponseMetadata"]][["RequestId"]])
+    r <- sesPOST(body = query,
+                 key = key,
+                 secret = secret,
+                 region = region,
+                 force_credentials = force_credentials,
+                 ...)
+    return(r)
 }

--- a/http.R
+++ b/http.R
@@ -1,0 +1,86 @@
+#' @title SES HTTP Requests
+#' @description Low-level SES POST function
+#' @param query A list containing query string parameters
+#' @param headers A list of headers to pass to the HTTP request.
+#' @param body A list of query-like parameters to be passed as a form-encoded message body.
+#' @param verbose A logical indicating whether to be verbose. Default is given by \code{options("verbose")}.
+#' @param region A character string specifying an AWS region. See \code{\link[aws.signature]{locate_credentials}}.
+#' @param key A character string specifying an AWS Access Key. See \code{\link[aws.signature]{locate_credentials}}.
+#' @param secret A character string specifying an AWS Secret Key. See \code{\link[aws.signature]{locate_credentials}}.
+#' @param session_token Optionally, a character string specifying an AWS temporary Session Token to use in signing a request. See \code{\link[aws.signature]{locate_credentials}}.
+#' @param \dots Additional arguments passed to \code{\link[httr]{POST}}.
+#' @import httr
+#' @importFrom aws.signature signature_v4_auth
+#' @importFrom utils URLencode
+#' @importFrom jsonlite fromJSON
+#' @export
+sesPOST <-
+function(
+  query = list(),
+  headers = list(),
+  body = NULL,
+  verbose = getOption("verbose", FALSE),
+  region = Sys.getenv("AWS_DEFAULT_REGION", "us-east-1"),
+  key = NULL,
+  secret = NULL,
+  session_token = NULL,
+  force_credentials = FALSE,
+  ...
+) {
+    # locate and validate credentials
+    if(!isTRUE(force_credentials)) {
+       credentials <- aws.signature::locate_credentials(key = key, secret = secret, session_token = session_token, region = region, verbose = verbose)
+       key <- credentials[["key"]]
+       secret <- credentials[["secret"]]
+       session_token <- credentials[["session_token"]]
+       region <- credentials[["region"]]
+    }
+
+    # generate request signature
+    uri <- paste0("https://email.",region,".amazonaws.com")
+    d_timestamp <- format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC")
+    body_to_sign <- if (is.null(body)) {
+        ""
+    } else {
+        paste0(names(body), "=", sapply(unname(body), utils::URLencode, reserved = TRUE), collapse = "&")
+    }
+    Sig <- aws.signature::signature_v4_auth(
+           datetime = d_timestamp,
+           region = region,
+           service = "email",
+           verb = "POST",
+           action = "/",
+           query_args = query,
+           canonical_headers = list(host = paste0("email.",region,".amazonaws.com"),
+                                    `x-amz-date` = d_timestamp),
+           request_body = body_to_sign,
+           key = key,
+           secret = secret,
+           session_token = session_token,
+           verbose = verbose)
+    # setup request headers
+    headers[["x-amz-date"]] <- d_timestamp
+    headers[["x-amz-content-sha256"]] <- Sig$BodyHash
+    headers[["Authorization"]] <- Sig[["SignatureHeader"]]
+    if (!is.null(session_token) && session_token != "") {
+        headers[["x-amz-security-token"]] <- session_token
+    }
+    H <- do.call(httr::add_headers, headers)
+
+    # execute request
+    if (length(query)) {
+        if (!is.null(body)) {
+            r <- httr::POST(uri, H, query = query, body = body, encode = "form", ...)
+        } else {
+            r <- httr::POST(uri, H, query = query, ...)
+        }
+    } else {
+        if (!is.null(body)) {
+            r <- httr::POST(uri, H, body = body, encode = "form", ...)
+        } else {
+            r <- httr::POST(uri, H, ...)
+        }
+    }
+
+    return(httr::http_status(r$status_code)$message)
+}

--- a/sendemail.R
+++ b/sendemail.R
@@ -1,0 +1,123 @@
+#' @rdname sendemail
+#' @title Send Email via SES
+#' @description Send email via Amazon SES service
+#' @param message A character string specifying the message body (as plain text). Must specify \code{html}, \code{message}, or both; or alternatively \code{raw}.
+#' @param html A character string specifying the message body (as HTML). Must specify \code{html}, \code{message}, or both; or alternatively \code{raw}.
+#' @param raw A raw vector containing a valid email body (of no more than 10MB in size). Can only specify \code{raw} xor \code{message}/\code{html}.
+#' @param subject A character string specifying the email subject
+#' @param from A character string specifying the sender. Must be AWS SES verified.
+#' @param to A character vector of TO recipient email addresses.
+#' @param cc A character vector of CC recipient email addresses.
+#' @param bcc A character vector of BCC recipient email addresses.
+#' @param replyto A character vector of reply-to email addresses.
+#' @param returnpath A character string specifying the email address to which feedback and bounces are sent.
+#' @param charset.message An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{message} is not ASCII.
+#' @param charset.html An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{html} is not ASCII.
+#' @param charset.subject An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{subject} is not ASCII.
+#' @param key A character string with the key from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param secret  A character string with the secret from from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param region A character string giving the region of the user's Amazon SES service. Note that AWS SES is only available in regions us-east-1, us-west-2, or eu-west-1.
+#' @param force_credentials A logical set to \code{TRUE} or \code{FALSE}. Use \code{TRUE} only if you are providing the key, secret, and region parameters.
+#' @template dots
+#' @details Send a test or raw email message. \code{get_quota} and \code{get_statistics} provide information on remaining and used email rate limits, respectively. To use Amazon SES from any host, in AWS Identity and Access Management (IAM), create a new user with no password, directly attach an SES permission policy (eg: AmazonSESFullAccess), then in that user's "Security credentials" tab, click "Create access key". This will allow you to download a .csv file with a key and secret to use here. In this case, also set the \code{region} parameter to the region of your Amazon SES service and the \code{force_credentials} parameter to \code{TRUE}.
+#' @return A character string containg the message ID.
+#' @examples
+#' \dontrun{
+#' # verify email address
+#' verify_identity("me@example.com")
+#'
+#' # if email verified, can be used to send a message
+#' a <- get_verification_attrs("me@example.com")
+#' if (a[[1]]$VerificationStatus == "Success") {
+#'   # simple plain-text email
+#'   send_email("Test Email Body", subject = "Test Email",
+#'              from = "me@example.com", to = "recipient@example.com")
+#'
+#'   # html and plain text versions
+#'   send_email(message = "Plain text body",
+#'              html = "<div><p style='font-weight=bold;'>HTML text body</p></div>",
+#'              subject = "Test Email",
+#'              from = "me@example.com", to = "recipient@example.com")
+#' }
+#' }
+#' @export
+send_email <-
+function(message,
+         html,
+         raw = NULL,
+         subject,
+         from,
+         to = NULL,
+         cc = NULL,
+         bcc = NULL,
+         replyto = NULL,
+         returnpath = NULL,
+         charset.subject = NULL,
+         charset.message = NULL,
+         charset.html = NULL,
+         key = NULL,
+         secret = NULL,
+         region = NULL,
+         force_credentials = FALSE,
+         ...) {
+
+    query <- list(Source = from)
+
+    # configure message body and subject
+    if (!is.null(raw)) {
+        query[["Action"]] <- "SendRawEmail"
+        query[["RawMessage"]] <- list(Data = raw)
+    } else {
+        query[["Action"]] <- "SendEmail"
+        if (missing(message) & missing(html)) {
+            stop("Must specify 'message', 'html', or both of them.")
+        }
+        if (!missing(message)) {
+            query[["Message.Body.Text.Data"]] <- message
+            if (!is.null(charset.message)) {
+                query[["Message.Message.Charset"]] <- charset.message
+            }
+        }
+        if (!missing(html)) {
+            query[["Message.Body.Html.Data"]] <- html
+            if (!is.null(charset.html)) {
+                query[["Message.Body.Html.Charset"]] <- charset.html
+            }
+        }
+        query[["Message.Subject.Data"]] <- subject
+        if (!is.null(charset.subject)) {
+            query[["Message.Subject.Charset"]] <- charset.subject
+        }
+    }
+
+    # configure recipients
+    if (length(c(to,cc,bcc)) > 50L) {
+        stop("The total number of recipients cannot exceed 50.")
+    }
+    if (!is.null(to)) {
+        names(to) <- paste0("Destination.ToAddresses.member.", seq_along(to))
+        query <- c(query, to)
+    }
+    if (!is.null(cc)) {
+        names(cc) <- paste0("Destination.CcAddresses.member.", seq_along(cc))
+        query <- c(query, cc)
+    }
+    if (!is.null(bcc)) {
+        names(bcc) <- paste0("Destination.BccAddresses.member.", seq_along(bcc))
+        query <- c(query, bcc)
+    }
+    if (!is.null(replyto)) {
+        names(replyto) <- paste0("ReplyToAddresses.member.", seq_along(replyto))
+        query <- c(query, replyto)
+    }
+    if (!is.null(returnpath)) {
+      query[["ReturnPath"]] <- returnpath
+    }
+    r <- sesPOST(body = query,
+                 key = key,
+                 secret = secret,
+                 region = region,
+                 force_credentials = force_credentials,
+                 ...)
+    return(r)
+}


### PR DESCRIPTION
This is my first pull request and I seem to have made a mess of it. Of the four files here only the last two (the ones with no "Verified" badge) are relevant. The "verified" ones are duplicates of the two good ones, but don't show additions/deletions.

The `sendemail.R` file contains a fix for issue 6, the `replyto` bug, at lines 109-112.

Most of the other changes in the two files have to do with issue 7. I fix this issue by allowing the user to enter key, secret, region, and force_credentials = TRUE in the `sendemail()` function. The region in this case is the region of the AWS SES server, which, in the long run, is unlikely to be the region of the user's instance. I also added a bit to the Details about how to get the needed key and secret from AWS.

The fix also involves putting an `if()` statement around some lines in http.R so that the user's credentials aren't over-written when `force_credentials = TRUE`.

With these changes **aws.ses** allows a user with the proper credentials to send email from any computer, not just an instance on AWS.

I also specified the package (using `::`) for functions that were in other packages so the user doesn't have to `library` or `require` them.

I also changed the message returned to the sendemail() function to a simple report of whether the POST was successful or not, with the error code and httr's message for that code. I probably shouldn't have mixed these fixes together. The old return message seemed to be mostly for debugging, not for production.

 - [ ] make sure `R CMD check` runs without error before submitting the PR

Sorry, `R CMD check` is over my head right now.

