### PR TITLE
Fixes for issues #6 and #7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,5 @@ Suggests:
     aws.sns
 URL: https://github.com/cloudyr/aws.ses
 BugReports: https://github.com/cloudyr/aws.ses/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
+Encoding: UTF-8

--- a/R/sendemail.R
+++ b/R/sendemail.R
@@ -14,6 +14,10 @@
 #' @param charset.message An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{message} is not ASCII.
 #' @param charset.html An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{html} is not ASCII.
 #' @param charset.subject An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{subject} is not ASCII.
+#' @param key A character string with the key from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param secret  A character string with the secret from from an Amazon user's access key who has permission to send email via Amazon SES.
+#' @param region A character string giving the region of the user's Amazon SES service. Note that AWS SES is only available in regions us-east-1, us-west-2, or eu-west-1.
+#' @param force_credentials A logical set to \code{TRUE} or \code{FALSE}. Use \code{TRUE} only if you are providing the key, secret, and region parameters.
 #' @template dots
 #' @details Send a test or raw email message. \code{get_quota} and \code{get_statistics} provide information on remaining and used email rate limits, respectively.
 #' @return A character string containg the message ID.
@@ -26,18 +30,18 @@
 #' a <- get_verification_attrs("me@example.com")
 #' if (a[[1]]$VerificationStatus == "Success") {
 #'   # simple plain-text email
-#'   send_email("Test Email Body", subject = "Test Email", 
+#'   send_email("Test Email Body", subject = "Test Email",
 #'              from = "me@example.com", to = "recipient@example.com")
-#' 
+#'
 #'   # html and plain text versions
-#'   send_email(message = "Plain text body", 
-#'              html = "<div><p style='font-weight=bold;'>HTML text body</p></div>", 
-#'              subject = "Test Email", 
+#'   send_email(message = "Plain text body",
+#'              html = "<div><p style='font-weight=bold;'>HTML text body</p></div>",
+#'              subject = "Test Email",
 #'              from = "me@example.com", to = "recipient@example.com")
 #' }
 #' }
 #' @export
-send_email <- 
+send_email <-
 function(message,
          html,
          raw = NULL,
@@ -51,9 +55,13 @@ function(message,
          charset.subject = NULL,
          charset.message = NULL,
          charset.html = NULL,
+         key = NULL,
+         secret = NULL,
+         region = NULL,
+         force_credentials = FALSE,
          ...) {
     query <- list(Source = from)
-    
+
     # configure message body and subject
     if (!is.null(raw)) {
         query[["Action"]] <- "SendRawEmail"
@@ -80,7 +88,7 @@ function(message,
             query[["Message.Subject.Charset"]] <- charset.subject
         }
     }
-    
+
     # configure recipients
     if (length(c(to,cc,bcc)) > 50L) {
         stop("The total number of recipients cannot exceed 50.")
@@ -97,15 +105,20 @@ function(message,
         names(bcc) <- paste0("Destination.BccAddresses.member.", seq_along(bcc))
         query <- c(query, bcc)
     }
-    
     if (!is.null(replyto)) {
-      query[["ReplyToAddresses"]] <- replyto
+        names(replyto) <- paste0("ReplyToAddresses.member.", seq_along(replyto))
+        query <- c(query, replyto)
     }
     if (!is.null(returnpath)) {
       query[["ReturnPath"]] <- returnpath
     }
-    
-    r <- sesPOST(body = query, ...)
+
+    r <- sesPOST(body = query,
+                 key = key,
+                 secret = secret,
+                 region = region,
+                 force_credentials = force_credentials,
+                 ...)
     structure(r[["SendEmailResponse"]][["SendEmailResult"]][["MessageId"]],
               RequestId = r[["SendEmailResponse"]][["ResponseMetadata"]][["RequestId"]])
 }

--- a/man/idnotification.Rd
+++ b/man/idnotification.Rd
@@ -7,8 +7,8 @@
 \usage{
 get_id_notification(identity, ...)
 
-set_id_notification(identity, type = c("Bounce", "Complaint", "Delivery"),
-  topic, ...)
+set_id_notification(identity, type = c("Bounce", "Complaint",
+  "Delivery"), topic, ...)
 }
 \arguments{
 \item{identity}{An SES identity.}

--- a/man/sendemail.Rd
+++ b/man/sendemail.Rd
@@ -6,9 +6,11 @@
 \alias{get_statistics}
 \title{Send Email via SES}
 \usage{
-send_email(message, html, raw = NULL, subject, from, to = NULL, cc = NULL,
-  bcc = NULL, replyto = NULL, returnpath = NULL, charset.subject = NULL,
-  charset.message = NULL, charset.html = NULL, ...)
+send_email(message, html, raw = NULL, subject, from, to = NULL,
+  cc = NULL, bcc = NULL, replyto = NULL, returnpath = NULL,
+  charset.subject = NULL, charset.message = NULL,
+  charset.html = NULL, key = NULL, secret = NULL, region = NULL,
+  force_credentials = FALSE, ...)
 
 get_quota(...)
 
@@ -41,6 +43,14 @@ get_statistics(...)
 
 \item{charset.html}{An optional character string specifying the character set, e.g., \dQuote{UTF-8}, \dQuote{ISO-8859-1}, etc. if \code{html} is not ASCII.}
 
+\item{key}{A character string with the key from an Amazon user's access key who has permission to send email via Amazon SES.}
+
+\item{secret}{A character string with the secret from from an Amazon user's access key who has permission to send email via Amazon SES.}
+
+\item{region}{A character string giving the region of the user's Amazon SES service. Note that AWS SES is only available in regions us-east-1, us-west-2, or eu-west-1.}
+
+\item{force_credentials}{A logical set to \code{TRUE} or \code{FALSE}. Use \code{TRUE} only if you are providing the key, secret, and region parameters.}
+
 \item{\dots}{Additional arguments passed to \code{\link{sesPOST}}.}
 }
 \value{
@@ -61,13 +71,13 @@ verify_identity("me@example.com")
 a <- get_verification_attrs("me@example.com")
 if (a[[1]]$VerificationStatus == "Success") {
   # simple plain-text email
-  send_email("Test Email Body", subject = "Test Email", 
+  send_email("Test Email Body", subject = "Test Email",
              from = "me@example.com", to = "recipient@example.com")
 
   # html and plain text versions
-  send_email(message = "Plain text body", 
-             html = "<div><p style='font-weight=bold;'>HTML text body</p></div>", 
-             subject = "Test Email", 
+  send_email(message = "Plain text body",
+             html = "<div><p style='font-weight=bold;'>HTML text body</p></div>",
+             subject = "Test Email",
              from = "me@example.com", to = "recipient@example.com")
 }
 }

--- a/man/sesPOST.Rd
+++ b/man/sesPOST.Rd
@@ -7,7 +7,8 @@
 sesPOST(query = list(), headers = list(), body = NULL,
   verbose = getOption("verbose", FALSE),
   region = Sys.getenv("AWS_DEFAULT_REGION", "us-east-1"), key = NULL,
-  secret = NULL, session_token = NULL, ...)
+  secret = NULL, session_token = NULL, force_credentials = FALSE,
+  ...)
 }
 \arguments{
 \item{query}{A list containing query string parameters}
@@ -25,6 +26,8 @@ sesPOST(query = list(), headers = list(), body = NULL,
 \item{secret}{A character string specifying an AWS Secret Key. See \code{\link[aws.signature]{locate_credentials}}.}
 
 \item{session_token}{Optionally, a character string specifying an AWS temporary Session Token to use in signing a request. See \code{\link[aws.signature]{locate_credentials}}.}
+
+\item{force_credentials}{A logical set to \code{TRUE} or \code{FALSE}. Use \code{TRUE} only if you are providing the key, secret, and region parameters.}
 
 \item{\dots}{Additional arguments passed to \code{\link[httr]{POST}}.}
 }


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.ses/issues/new) first
Issues 6 and 7.
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.ses/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.ses/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.ses/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

The replyto issue, #6, is fixed in  sendemail.R at lines 108-111.

The other changes in the two files have to do with issue 7. I fix this issue by allowing the user to enter key, secret, region, and force_credentials = TRUE in the send_email() function. The region in this case is the region of the AWS SES server, which, in the long run, is unlikely to be the region of the user's instance. I also added a bit to the Details about how to get the needed key and secret from AWS.

The fix also involves putting an if() statement around the locate_credentials call in http.R so that the user's credentials aren't over-written when force_credentials = TRUE and so that the region parameter in send_email() remains the SES region, not the instance region.

As an added side-effect, with these changes aws.ses allows a user with the proper credentials to send email from any computer, not just an instance on AWS.
